### PR TITLE
Change order status test

### DIFF
--- a/demostore_automation/src/api_helpers/CustomerAPIHelper.py
+++ b/demostore_automation/src/api_helpers/CustomerAPIHelper.py
@@ -1,0 +1,32 @@
+"""WooCommerce Customer API helper module.
+
+Provides helper methods for interacting with WooCommerce customer endpoints;
+"""
+
+from demostore_automation.src.utilities.wooAPIUtility import WooAPIUtility
+
+
+class CustomerAPIHelper:
+    """Helper for performing WooCommerce customer API operations.
+
+    Attributes:
+        woo_api_utility (WooAPIUtility): Instance used to make WooCommerce API requests.
+    """
+
+    def __init__(self):
+        self.woo_api_utility = WooAPIUtility()
+
+    def call_delete_customer(self, customer_id, force=True):
+        """Delete a WooCommerce customer via API.
+
+        WooCommerce does not support trashing customers. This method permanently deletes
+        the customer when `force=True`.
+
+        Args:
+            customer_id (int): The ID of the customer to delete.
+            force (bool, optional): Whether to permanently delete the customer. Defaults to True.
+
+        Returns:
+            dict: Response from the WooCommerce API.
+        """
+        return self.woo_api_utility.delete(f"customers/{customer_id}", params={"force": force})

--- a/demostore_automation/src/api_helpers/OrdersAPIHelper.py
+++ b/demostore_automation/src/api_helpers/OrdersAPIHelper.py
@@ -100,4 +100,5 @@ class OrdersAPIHelper:
         """
         return self.woo_api_utility.delete(f'orders/{order_id}/notes/{note_id}', params=params)
 
-
+    def call_create_refund(self, order_id, payload):
+        return self.woo_api_utility.post(f'orders/{order_id}/refunds/', params=payload)

--- a/demostore_automation/src/api_helpers/ProductsAPIHelper.py
+++ b/demostore_automation/src/api_helpers/ProductsAPIHelper.py
@@ -37,3 +37,11 @@ class ProductsAPIHelper:
 
     def call_delete_product(self, product_id):
         return self.woo_api_utility.delete(f"products/{product_id}")
+
+
+    def call_create_review(self, payload, expected_status_code=201):
+        return self.woo_api_utility.post("products/reviews", params=payload, expected_status_code=expected_status_code)
+
+
+    def call_retrieve_reviews(self, product_id):
+        return self.woo_api_utility.get("products/reviews", params={"product": product_id})

--- a/demostore_automation/src/dao/orders_dao.py
+++ b/demostore_automation/src/dao/orders_dao.py
@@ -86,3 +86,23 @@ class OrdersDAO:
         rs_sql = self.db_helper.execute_select(sql)
         logger.info(f"Found {len(rs_sql)} orders with note '{note_text}'")
         return rs_sql
+
+
+    def get_order_status_by_id(self, order_id):
+        """Fetch order status from the database using its ID.
+
+        Args:
+            order_id (int): The ID of the order to retrieve.
+
+        Returns:
+            list[dict]: A list containing a single dictionary with the order's database fields.
+
+        Raises:
+            Exception: If the database query fails or no matching order is found.
+        """
+        sql = f"""
+        SELECT status FROM {self.db_helper.database}.{self.db_helper.table_prefix}wc_orders
+        WHERE id = {order_id};
+        """
+        return self.db_helper.execute_select(sql)
+

--- a/demostore_automation/src/dao/products_dao.py
+++ b/demostore_automation/src/dao/products_dao.py
@@ -74,3 +74,17 @@ class ProductsDAO:
         WHERE post_id = {product_id} AND meta_key IN ('_regular_price', '_sale_price', '_price');
         """
         return self.db_helper.execute_select(sql)
+
+    def get_product_review_info(self, product_id):
+        """Fetch the review-related fields of a product from the database.
+
+        Args:
+            product_id (int): ID of the product.
+
+        Returns:
+            list[dict]: A list containing a single dictionary with the product's database fields.
+        """
+        sql = f""" SELECT * FROM {self.db_helper.database}.{self.db_helper.table_prefix}comments
+        WHERE comment_type = 'comment' and comment_post_ID = {product_id};
+        """
+        return self.db_helper.execute_select(sql)

--- a/demostore_automation/src/generic_helpers/generic_orders_helper.py
+++ b/demostore_automation/src/generic_helpers/generic_orders_helper.py
@@ -212,3 +212,31 @@ class GenericOrdersHelper:
                                                                                      f"Actual: {get_response['refunds']['total']}"
                                                                                      f"Expected: -{get_response['total']}")
 
+
+    def create_order_refund(self, order_response, refund_type, additional_args=None):
+        order_id = order_response['id']
+        order_total = float(order_response['total'])
+        if refund_type == 'full':
+            refund_amount = order_response['total']
+        elif refund_type == 'partial': # half refund
+            refund_amount = round(order_total / 2, 2)
+        elif refund_type == 'refund_1_product':
+            refund_amount = float(order_response['line_items'][0]['price'])
+
+        refund_payload = {
+            "amount": str(refund_amount),  # total refund amount
+            "line_items": [
+                {
+                    "id": order_response['line_items'][0]['id'],
+                    "quantity": 1  # instead of refund_total
+                }
+            ],
+            "refund_payment": False
+        }
+        response = self.orders_api_helper.call_create_refund(
+            order_id=order_id,
+            payload=refund_payload
+        )
+        return response
+
+

--- a/demostore_automation/src/generic_helpers/generic_orders_helper.py
+++ b/demostore_automation/src/generic_helpers/generic_orders_helper.py
@@ -214,6 +214,25 @@ class GenericOrdersHelper:
 
 
     def create_order_refund(self, order_response, refund_type, additional_args=None):
+        """Create a refund for a WooCommerce order.
+
+        Supports full order refunds, partial (half) refunds, and single-product refunds.
+
+        Args:
+            order_response (dict): API response dict of the order to refund, must include 'id', 'total', and 'line_items'.
+            refund_type (str): Type of refund to apply. One of:
+                - "full": refund the entire order total.
+                - "partial": refund half of the order total.
+                - "refund_1_product": refund only the first product in the order.
+            additional_args (dict, optional): Extra payload parameters for the refund API call. Defaults to None.
+
+        Returns:
+            dict: API response of the created refund.
+
+        Raises:
+            KeyError: If expected keys ('id', 'total', 'line_items') are missing from order_response.
+            ValueError: If refund_type is not one of the allowed types.
+        """
         order_id = order_response['id']
         order_total = float(order_response['total'])
         if refund_type == 'full':

--- a/demostore_automation/src/generic_helpers/generic_products_helper.py
+++ b/demostore_automation/src/generic_helpers/generic_products_helper.py
@@ -220,3 +220,22 @@ class GenericProductsHelper:
                                                     f"Actual: {post_response['code']}")
 
         assert param in post_response['message'], f"Expected message in api response should contain the parameter."
+
+
+    def create_product_review(self, product_id, rating, reviewer=None, email=None):
+        if reviewer is None:
+            reviewer = "Guest User"
+        if email is None:
+            email = "guest@example.com"
+
+        payload = {
+            "product_id": product_id,
+            "review": 'test review',
+            "reviewer": reviewer,
+            "reviewer_email": email,
+            "rating": rating,
+        }
+        create_review = self.products_api_helper.call_create_review(payload)
+        return create_review
+
+

--- a/demostore_automation/tests/backend/orders/test_change_order_status.py
+++ b/demostore_automation/tests/backend/orders/test_change_order_status.py
@@ -13,7 +13,8 @@ pytestmark = [pytest.mark.orders, pytest.mark.order_status]
         pytest.param("completed", marks=[pytest.mark.ebe48, pytest.mark.smoke], id="update to completed"),
         pytest.param("cancelled", marks=[pytest.mark.ebe49], id="update to cancelled"),
         pytest.param("refunded",  marks=[pytest.mark.ebe51], id="update to refunded"),
-        pytest.param("failed", marks=[pytest.mark.ebe50], id="update to failed")
+        pytest.param("failed", marks=[pytest.mark.ebe50], id="update to failed"),
+        pytest.param("processing", marks=[pytest.mark.ebe50], id="update to same status")
     ]
 )
 
@@ -26,7 +27,7 @@ def test_change_order_status(my_orders_smoke_setup, order_status):
 
 
     #create payload 'line_items' with custom product
-    create_payload = {"line_items": [{"product_id": product_id}]}
+    create_payload = {"status": "processing","line_items": [{"product_id": product_id}]}
 
     # make api call to create order
     create_order_responses = my_orders_smoke_setup["generic_orders_helper"].create_order(additional_args=create_payload)

--- a/demostore_automation/tests/backend/orders/test_change_order_status.py
+++ b/demostore_automation/tests/backend/orders/test_change_order_status.py
@@ -1,0 +1,61 @@
+
+import pytest
+import logging as logger
+from demostore_automation.tests.backend.orders.test_create_order_smoke import my_orders_smoke_setup
+
+
+pytestmark = [pytest.mark.orders, pytest.mark.order_status]
+
+@pytest.mark.parametrize(
+     "order_status",
+    [
+        pytest.param("on-hold", marks=[pytest.mark.ebe47], id="update to on-hold"),
+        pytest.param("completed", marks=[pytest.mark.ebe48, pytest.mark.smoke], id="update to completed"),
+        pytest.param("cancelled", marks=[pytest.mark.ebe49], id="update to cancelled"),
+        pytest.param("refunded",  marks=[pytest.mark.ebe51], id="update to refunded"),
+        pytest.param("failed", marks=[pytest.mark.ebe50], id="update to failed")
+    ]
+)
+
+def test_change_order_status(my_orders_smoke_setup, order_status):
+    # fetch product and customer
+    # create order
+    product_id = my_orders_smoke_setup["product_id"]
+    product_price = my_orders_smoke_setup["product_price"]
+    logger.info(f"Product ID: {product_id}, Product price: {product_price}")
+
+
+    #create payload 'line_items' with custom product
+    create_payload = {"line_items": [{"product_id": product_id}]}
+
+    # make api call to create order
+    create_order_responses = my_orders_smoke_setup["generic_orders_helper"].create_order(additional_args=create_payload)
+    for create_order_response in create_order_responses:
+        assert create_order_response, f"Create order API response is empty"
+
+        order_id = create_order_response['id']
+
+        # verify default order status == 'processing'
+        assert create_order_response['status'] == 'processing', (f"Default order status should be 'processing',"
+                                                                 f"Actual: {create_order_response['status']}")
+
+        my_orders_smoke_setup["order_ids"].append(order_id) # keeps track of newly created order_id for teardown
+
+        # make UPDATE call with new status
+        update_payload = {"status": order_status}
+        update_response = my_orders_smoke_setup["orders_api_helper"].call_update_order(order_id, payload=update_payload)
+        logger.info(f"UPDATE api response after changing order_status: {update_response}")
+        # verify order status
+        assert update_response['status'] == order_status, (f"Order status after update call: {update_response['status']}"
+                                                           f"Expected: {order_status}")
+        # verify order is the same
+        assert update_response['id'] == order_id, (f"Error. Wrong order_id after update api call. Expected: {order_id}"
+                                                   f"Actual: {update_response['id']}")
+
+        # verify newly updated order via GET api call and DB query
+        get_response = my_orders_smoke_setup["generic_orders_helper"].verify_new_order_exists(order_id)
+        logger.info(f"GET response: {get_response}")
+
+        # verify correct status in API and DB, and for certain statuses (completed, cancelled, refunded),
+        # check that specific fields like 'needs_payment', 'date_completed', and 'refunds' are correct
+        my_orders_smoke_setup['generic_orders_helper'].verify_order_status(get_response, order_status)

--- a/demostore_automation/tests/backend/orders/test_create_order_notes.py
+++ b/demostore_automation/tests/backend/orders/test_create_order_notes.py
@@ -11,7 +11,7 @@ from demostore_automation.src.api_helpers.OrdersAPIHelper import OrdersAPIHelper
 from demostore_automation.src.dao.customers_dao import CustomersDAO
 from demostore_automation.src.dao.products_dao import ProductsDAO
 from demostore_automation.src.generic_helpers.generic_orders_helper import GenericOrdersHelper
-
+pytestmark = [pytest.mark.orders, pytest.mark.order_notes]
 @pytest.fixture(scope="module")
 def order_notes_setup():
     """Set up DAOs, helpers, a random product, default note text, and track created orders."""
@@ -46,10 +46,10 @@ def order_notes_setup():
 @pytest.mark.parametrize(
     "user_type, quantity",
     [
-        pytest.param("guest_user", 1, marks=[pytest.mark.ecomnotes, pytest.mark.ecomnotes1], id="guestuser_1_note"),
-        pytest.param("guest_user", 5, marks=[pytest.mark.ecomnotes, pytest.mark.ecomnotes1], id="guestuser_5_notes"),
-        pytest.param("registered_user", 1, marks=[pytest.mark.ecomnotes, pytest.mark.ecomnotes2], id="reg_user_1_notes"),
-        pytest.param("registered_user", 5, marks=[pytest.mark.ecomnotes, pytest.mark.ecomnotes2], id="reg_user_5_notes")
+        pytest.param("guest_user", 1, marks=[pytest.mark.ebe58, pytest.mark.smoke], id="guestuser_1_note"),
+        pytest.param("guest_user", 5, marks=[pytest.mark.ebe59], id="guestuser_5_notes"),
+        pytest.param("registered_user", 1, marks=[pytest.mark.ebe60], id="reg_user_1_notes"),
+        pytest.param("registered_user", 5, marks=[pytest.mark.ebe61], id="reg_user_5_notes")
     ]
 )
 @pytest.mark.ordernotes

--- a/demostore_automation/tests/backend/orders/test_create_order_smoke.py
+++ b/demostore_automation/tests/backend/orders/test_create_order_smoke.py
@@ -14,6 +14,8 @@ from demostore_automation.src.dao.customers_dao import CustomersDAO
 from demostore_automation.src.dao.products_dao import ProductsDAO
 from demostore_automation.src.generic_helpers.generic_orders_helper import GenericOrdersHelper
 
+pytestmark = [pytest.mark.orders, pytest.mark.smoke]
+
 @pytest.fixture(scope="module")
 def my_orders_smoke_setup():
     """Setup fixture for creating and cleaning up test orders.
@@ -54,12 +56,12 @@ def my_orders_smoke_setup():
 @pytest.mark.parametrize(
      "user_type, order_qty, product_qty",
     [
-        pytest.param("guest_user", 1, 5, marks=[pytest.mark.orders, pytest.mark.ecomorders1], id="guestuser_1_ord_5_prods"),
-        pytest.param("guest_user", 5, 1, marks=[pytest.mark.orders, pytest.mark.ecomorders1], id="guestuser_5_ord_1_prod"),
-        pytest.param("guest_user", 1, 1, marks=[pytest.mark.orders, pytest.mark.ecomorders1], id="guestuser_1_ord_1_prod"),
-        pytest.param("registered_user", 1, 5, marks=[pytest.mark.orders, pytest.mark.ecomorders2], id="reg_user_1_ord_5_prods"),
-        pytest.param("registered_user", 5, 1, marks=[pytest.mark.orders, pytest.mark.ecomorders2], id="reg_user_5_ord_1_prod"),
-        pytest.param("registered_user", 5, 5, marks=[pytest.mark.orders, pytest.mark.ecomorders2], id="reg_user_5_ord_5_prod")
+        pytest.param("guest_user", 1, 5, marks=[pytest.mark.ebe52], id="guestuser_1_ord_5_prods"),
+        pytest.param("guest_user", 5, 1, marks=[pytest.mark.ebe53], id="guestuser_5_ord_1_prod"),
+        pytest.param("guest_user", 1, 1, marks=[pytest.mark.ebe54], id="guestuser_1_ord_1_prod"),
+        pytest.param("registered_user", 1, 5, marks=[pytest.mark.ebe55], id="reg_user_1_ord_5_prods"),
+        pytest.param("registered_user", 5, 1, marks=[pytest.mark.ebe56], id="reg_user_5_ord_1_prod"),
+        pytest.param("registered_user", 5, 5, marks=[pytest.mark.ebe57], id="reg_user_5_ord_5_prod")
     ]
 )
 

--- a/demostore_automation/tests/backend/orders/test_order_refunds.py
+++ b/demostore_automation/tests/backend/orders/test_order_refunds.py
@@ -1,3 +1,12 @@
+"""Test module for WooCommerce order refunds.
+
+Covers full, partial, and single-product refunds via the API. Includes:
+- Verification of refund amounts.
+- Edge case testing for refund types.
+- Marking tests as xfail for unsupported automatic refunds.
+
+Uses pytest for parametrization and fixtures.
+"""
 import pytest
 import logging as logger
 from demostore_automation.tests.backend.orders.test_create_order_smoke import my_orders_smoke_setup
@@ -17,15 +26,31 @@ pytestmark = [pytest.mark.orders, pytest.mark.order_refund]
 )
 
 def test_order_refund(my_orders_smoke_setup, refund_type):
+    """Test WooCommerce order refunds via API.
+
+    Steps:
+    1. Create a new order with a product.
+    2. Apply refund based on `refund_type`:
+       - full: refund entire order
+       - partial: refund half the order
+       - refund_1_product: refund a single product
+    3. Verify that the refund amount returned by the API matches expected value.
+
+    Args:
+        my_orders_smoke_setup (fixture): Fixture providing product, order, and helper setup.
+        refund_type (str): Type of refund to apply. One of "full", "partial", "refund_1_product".
+
+    Assertions:
+        - Order creation API returns valid responses.
+        - Refund API returns the correct refund amount.
+    """
     # fetch product and customer
     # create order
     product_id = my_orders_smoke_setup["product_id"]
     product_price = my_orders_smoke_setup["product_price"]
     logger.info(f"Product ID: {product_id}, Product price: {product_price}")
 
-
     #create payload 'line_items' with custom product
-    # create_payload = {"status": "processing","line_items": [{"product_id": product_id}]}
     create_payload = {
         "status": "processing",
         "payment_method": "bacs",

--- a/demostore_automation/tests/backend/orders/test_order_refunds.py
+++ b/demostore_automation/tests/backend/orders/test_order_refunds.py
@@ -1,0 +1,65 @@
+import pytest
+import logging as logger
+from demostore_automation.tests.backend.orders.test_create_order_smoke import my_orders_smoke_setup
+
+pytestmark = [pytest.mark.orders, pytest.mark.order_refund]
+
+@pytest.mark.xfail(reason=" Response Json: {'code': 'woocommerce_rest_cannot_create_order_refund',"
+                          "'message': 'The payment gateway for this order does not support automatic refunds.', 'data': 500}")
+@pytest.mark.order_status_edge
+@pytest.mark.parametrize(
+     "refund_type",
+    [
+        pytest.param("full", marks=[pytest.mark.ebe47], id="update to same status"),
+        pytest.param("partial", marks=[pytest.mark.ebe48, pytest.mark.smoke], id="update to empty string"),
+        pytest.param("refund_1_product", marks=[pytest.mark.ebe49], id="update to random string")
+    ]
+)
+
+def test_order_refund(my_orders_smoke_setup, refund_type):
+    # fetch product and customer
+    # create order
+    product_id = my_orders_smoke_setup["product_id"]
+    product_price = my_orders_smoke_setup["product_price"]
+    logger.info(f"Product ID: {product_id}, Product price: {product_price}")
+
+
+    #create payload 'line_items' with custom product
+    # create_payload = {"status": "processing","line_items": [{"product_id": product_id}]}
+    create_payload = {
+        "status": "processing",
+        "payment_method": "bacs",
+        "payment_method_title": "bacs",
+        "line_items": [{"product_id": product_id}]
+    }
+    # make api call to create order
+    product_qty = 2 if refund_type == 'refund_1_product' else 1
+    create_order_responses = my_orders_smoke_setup["generic_orders_helper"].create_order(additional_args=create_payload,
+                                                                                         product_qty=product_qty)
+    for create_order_response in create_order_responses:
+        assert create_order_response, f"Create order API response is empty"
+
+        order_id = create_order_response['id']
+
+        my_orders_smoke_setup["order_ids"].append(order_id) # keeps track of newly created order_id for teardown
+
+        # make UPDATE call with refund
+        update_response = (my_orders_smoke_setup['generic_orders_helper'].create_order_refund(order_response=create_order_response,
+                                                                                              refund_type=refund_type))
+
+        logger.info(f"Update response: {update_response}")
+
+        # calculate expected refund amount
+        if refund_type == "full":
+            expected_amount = float(create_order_response['total'])
+        elif refund_type == "partial":
+            expected_amount = round(float(create_order_response['total']) / 2, 2)
+        elif refund_type == "refund_1_product":
+            expected_amount = float(create_order_response['line_items'][0]['price'])
+
+        # assert against API response
+        assert float(update_response["amount"]) == expected_amount, (
+            f"Incorrect refund amount after update call. Expected: {expected_amount}, "
+            f"Actual: {update_response['amount']}"
+        )
+

--- a/demostore_automation/tests/backend/products/test_create_product_reviews.py
+++ b/demostore_automation/tests/backend/products/test_create_product_reviews.py
@@ -1,6 +1,17 @@
+"""Test module for creating and verifying WooCommerce product reviews.
+
+This module covers API and DB verification for product reviews, including:
+- Reviews by guest users
+- Reviews by registered customers
+- Boundary testing for ratings (0-5)
+- Invalid rating handling (>5, expected to xfail) as woocommerce expects a max rating of 5
+
+Tests are parametrized using pytest.
+"""
 import pytest
 import logging as logger
 
+from demostore_automation.src.api_helpers.CustomerAPIHelper import CustomerAPIHelper
 from demostore_automation.src.generic_helpers.generic_orders_helper import GenericOrdersHelper
 from demostore_automation.src.utilities.genericUtilities import generate_random_email_and_password
 from demostore_automation.src.utilities.wooAPIUtility import WooAPIUtility
@@ -10,14 +21,34 @@ from demostore_automation.tests.backend.products.test_create_products_smoke impo
 @pytest.mark.parametrize(
      "rating, customer_bought",
     [
-        pytest.param(0, False, marks=[pytest.mark.a], id="review-lowest boundary"),
-        pytest.param(5, False, marks=[pytest.mark.b], id="review-highest boundary"),
-        pytest.param(10, False, marks=[pytest.mark.c, pytest.mark.xfail], id="review-out of range"),
-        pytest.param(4, True, marks=[pytest.mark.c], id="registered customer review"),
+        pytest.param(0, False, marks=[pytest.mark.ebe62], id="review-lowest boundary"),
+        pytest.param(5, False, marks=[pytest.mark.ebe63], id="review-highest boundary"),
+        pytest.param(10, False, marks=[pytest.mark.ebe64, pytest.mark.xfail(
+                                                              reason='rating of >5 is invalid. valid:0-5')],
+                                                              id="review-out of range"),
+        pytest.param(4, True, marks=[pytest.mark.ebe65], id="registered customer review"),
 
     ]
 )
 def test_create_product_review(setup_teardown, rating, customer_bought):
+    """Test creation and verification of a product review.
+
+    Steps:
+    1. Create a simple product via API.
+    2. Optionally create a registered customer and order if `customer_bought` is True.
+    3. Create a product review with the given rating.
+    4. Verify review exists and is correct via both API and database.
+
+    Args:
+        setup_teardown (fixture): Fixture providing product helpers, API helpers, and teardown logic.
+        rating (int): Rating for the review (0-5 recommended).
+        customer_bought (bool): Whether the review is by a registered customer.
+
+    Assertions:
+        - Review exists in API response with correct rating, status, and reviewer info.
+        - Review exists in DB with correct customer_id (if registered), email, and approved status.
+    """
+    created_customers = []  # for teardown
     post_response = setup_teardown['generic_products_helper'].create_product_by_type('simple')
 
     logger.info(f"product: {post_response}")
@@ -33,12 +64,15 @@ def test_create_product_review(setup_teardown, rating, customer_bought):
             }
         create_cust = WooAPIUtility().post("customers", params=payload, expected_status_code=201)
         customer_id = create_cust['id']
+        created_customers.append(customer_id)
         generic_orders_helper = GenericOrdersHelper()
         payload = {
             "customer_id": customer_id,
             "line_items": [{"product_id": product_id, "quantity": 1}],
             "status": "completed",
             "billing": {
+                "first_name": "Test_f",
+                "last_name": "Test_l",
                 "email": random_email
             }
         }
@@ -52,7 +86,7 @@ def test_create_product_review(setup_teardown, rating, customer_bought):
             product_id,
             rating,
             reviewer="Test User",
-            email=random_email  # <- must match the customer who bought
+            email=random_email  # registered customer's email
         )
     else:
         review_response = setup_teardown['generic_products_helper'].create_product_review(
@@ -61,15 +95,16 @@ def test_create_product_review(setup_teardown, rating, customer_bought):
         )
     logger.info(f"Review response: {review_response}")
 
-    # verify review persisted via api and db
-    reviews = setup_teardown['products_api_helper'].call_retrieve_reviews(product_id)
-    if rating > 5:
-        assert reviews[0]['rating'] == 5, f"Error. The maximum rating is 5. Rating in api: {reviews[0]['rating']}"
-    logger.info(f"reviews: {reviews}")
-    assert reviews, f"Get reviews response is empty after review for product id: {product_id}"
-    assert 'test review' in reviews[0]['review']
-    assert reviews[0]['status'] == "approved"
-    if customer_bought:
-        assert reviews[0]['verified']
-    else:
-        assert not reviews[0]['verified']
+    cust_id = customer_id if customer_bought else None
+    email_to_pass = random_email if customer_bought else None
+
+    setup_teardown['generic_products_helper'].verify_product_review_exists(product_id, rating, customer_bought,
+                                                                           customer_id=cust_id,
+                                                                           reviewer_email=email_to_pass
+                                                                           )
+    for customer_id in created_customers: # customer teardown
+        try:
+            CustomerAPIHelper().call_delete_customer(customer_id)
+        except Exception as e:
+            logger.error(f"Failed to delete customer with id {customer_id}. Error: {e}")
+    logger.info(f"Successfully deleted customer(s) with id(s): {created_customers}")

--- a/demostore_automation/tests/backend/products/test_create_product_reviews.py
+++ b/demostore_automation/tests/backend/products/test_create_product_reviews.py
@@ -1,0 +1,75 @@
+import pytest
+import logging as logger
+
+from demostore_automation.src.generic_helpers.generic_orders_helper import GenericOrdersHelper
+from demostore_automation.src.utilities.genericUtilities import generate_random_email_and_password
+from demostore_automation.src.utilities.wooAPIUtility import WooAPIUtility
+from demostore_automation.tests.backend.products.test_create_products_smoke import setup_teardown
+
+@pytest.mark.review
+@pytest.mark.parametrize(
+     "rating, customer_bought",
+    [
+        pytest.param(0, False, marks=[pytest.mark.a], id="review-lowest boundary"),
+        pytest.param(5, False, marks=[pytest.mark.b], id="review-highest boundary"),
+        pytest.param(10, False, marks=[pytest.mark.c, pytest.mark.xfail], id="review-out of range"),
+        pytest.param(4, True, marks=[pytest.mark.c], id="registered customer review"),
+
+    ]
+)
+def test_create_product_review(setup_teardown, rating, customer_bought):
+    post_response = setup_teardown['generic_products_helper'].create_product_by_type('simple')
+
+    logger.info(f"product: {post_response}")
+
+    product_id = post_response['id']
+    setup_teardown['product_ids'].append(product_id)
+    if customer_bought:
+        random_email = generate_random_email_and_password(email_prefix="test_user")["email"]
+        password = "Password123abc!"
+        payload = {
+            "email": random_email,
+            "password": password
+            }
+        create_cust = WooAPIUtility().post("customers", params=payload, expected_status_code=201)
+        customer_id = create_cust['id']
+        generic_orders_helper = GenericOrdersHelper()
+        payload = {
+            "customer_id": customer_id,
+            "line_items": [{"product_id": product_id, "quantity": 1}],
+            "status": "completed",
+            "billing": {
+                "email": random_email
+            }
+        }
+        create_order_responses = generic_orders_helper.create_order(additional_args=payload)
+        for create_order_response in create_order_responses:
+            assert create_order_response, f"Create order as guest user API response is empty"
+
+    if customer_bought:
+        # create customer & order as before
+        review_response = setup_teardown['generic_products_helper'].create_product_review(
+            product_id,
+            rating,
+            reviewer="Test User",
+            email=random_email  # <- must match the customer who bought
+        )
+    else:
+        review_response = setup_teardown['generic_products_helper'].create_product_review(
+            product_id,
+            rating
+        )
+    logger.info(f"Review response: {review_response}")
+
+    # verify review persisted via api and db
+    reviews = setup_teardown['products_api_helper'].call_retrieve_reviews(product_id)
+    if rating > 5:
+        assert reviews[0]['rating'] == 5, f"Error. The maximum rating is 5. Rating in api: {reviews[0]['rating']}"
+    logger.info(f"reviews: {reviews}")
+    assert reviews, f"Get reviews response is empty after review for product id: {product_id}"
+    assert 'test review' in reviews[0]['review']
+    assert reviews[0]['status'] == "approved"
+    if customer_bought:
+        assert reviews[0]['verified']
+    else:
+        assert not reviews[0]['verified']


### PR DESCRIPTION
added tests for create product reviews and xfail tests for create order refunds. Potentially may add on to refund test by installing plugin 'stripe' as 'bacs' does not support automatic refunds for woocommerce api.